### PR TITLE
Fix issue #22

### DIFF
--- a/Resources/views/Menu/foundation_breadcrumb.html.twig
+++ b/Resources/views/Menu/foundation_breadcrumb.html.twig
@@ -1,9 +1,9 @@
 {% block root -%}
-
-    <ul class="breadcrumbs">
-        {%- for breadcrumb in breadcrumbs -%}
-            <li><a href="{{ breadcrumb.uri }}">{{ breadcrumb.label }}</a></li>
-        {%- endfor -%}
-    </ul>
-
+    {% if breadcrumbs|length > 0 -%}
+        <ul class="breadcrumbs">
+            {%- for breadcrumb in breadcrumbs -%}
+                <li><a href="{{ breadcrumb.uri }}">{{ breadcrumb.label }}</a></li>
+            {%- endfor -%}
+        </ul>
+    {%- endif %}
 {%- endblock %}

--- a/Twig/MenuExtension.php
+++ b/Twig/MenuExtension.php
@@ -98,9 +98,17 @@ class MenuExtension extends \Twig_Extension
         $itemFilterIterator = new CurrentItemFilterIterator($treeIterator, $this->matcher);
         $itemFilterIterator->rewind();
 
-        // Extract the items for the breadcrumb
+        // Watch for a current item
+        $current = $itemFilterIterator->current();
+
         $manipulator = new MenuManipulator();
-        $breadcrumbs = $manipulator->getBreadcrumbsArray($itemFilterIterator->current());
+        if ($current instanceof ItemInterface) {
+            // Extract the items for the breadcrumb
+            $breadcrumbs = $manipulator->getBreadcrumbsArray($current);
+        } else {
+            // Current item could not be located, we only send the first item
+            $breadcrumbs = $manipulator->getBreadcrumbsArray($menu);
+        }
 
         // Load the template if needed
         if (!$options['template'] instanceof \Twig_Template) {


### PR DESCRIPTION
Instead of having an empty breadcrumb if the current item cannot be located, the breadcrumb display only the first item (usually homepage).