### PR TITLE
Extend KnpMenu bundle template, fixes menu trannslations

### DIFF
--- a/Resources/views/Menu/foundation_knp_menu.html.twig
+++ b/Resources/views/Menu/foundation_knp_menu.html.twig
@@ -1,4 +1,4 @@
-{% extends 'knp_menu.html.twig' %}
+{% extends 'KnpMenuBundle::menu.html.twig' %}
 
 {% block root %}
     {% set isTopBar = 'topbar' == item.extra('menu_type') %}


### PR DESCRIPTION
Extend the menu template from KnpMenuBundle instead of the KnpMenu
library. This allows menu items to be translated.
